### PR TITLE
Require authentication for unsafe requests

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,16 @@
+{
+    "server": {
+        "protocol": "http",
+        "host": "localhost:3000"
+    },
+    "microauth": {
+        "authorize_url": "http://127.0.0.1:8000/oauth2/authorize/",
+        "access_url": "http://127.0.0.1:8000/oauth2/token/",
+        "oauth": 2,
+        "key": "",
+        "secret": "",
+        "scope": ["publishing.read", "publishing.write", "publishing.delete"],
+        "scope_delimiter": " ",
+        "callback": "/done"
+    }
+}

--- a/index.js
+++ b/index.js
@@ -21,11 +21,13 @@ app.use( bodyParser.json() );
 app.use(morgan('dev'));
 
 var REQUIRE_AUTH = {
-    LIST: false,
+    LIST: true,
     DETAIL: false,
     SAVE: true,
     DELETE: true
 }
+
+var REDIRECT_TO_AUTHORIZE = true;
 
 function isCredentialExpired(oauth2) {
     return oauth2.issued_at + oauth2.expires_in < Date.now()
@@ -40,14 +42,20 @@ app.use(function(req, res, next) {
 app.post("/save_article", function (req, res) {
     if (REQUIRE_AUTH.SAVE && !req.session.oauth2) {
         req.session.next = req.url
-        res.sendStatus(401, 'You need to be authenticated to do this action.')
-        // res.redirect('/connect/microauth')
+        if (REDIRECT_TO_AUTHORIZE) {
+            res.redirect('/connect/microauth')
+        } else {
+            res.sendStatus(401, 'You need to be authenticated to do this action.')
+        }
         return
     } else if (REQUIRE_AUTH) {
         if (isCredentialExpired(req.session.oauth2)) {
             req.session.next = req.url
-            res.sendStatus(401, 'Signature has expired, please re-authenticate.')
-            // res.redirect('/connect/microauth')
+            if (REDIRECT_TO_AUTHORIZE) {
+                res.redirect('/connect/microauth')
+            } else {
+                res.sendStatus(401, 'Signature has expired, please re-authenticate.')
+            }
             return
         }
     }
@@ -106,8 +114,11 @@ app.get('/done', function (req, res) {
 app.get("/list", function (req, res) {
     if (REQUIRE_AUTH.LIST && (!req.session || !req.session.oauth2)) {
         req.session.next = req.url
-        res.sendStatus(401, 'You need to be authenticated to do this action.')
-        // res.redirect('/connect/microauth')
+        if (REDIRECT_TO_AUTHORIZE) {
+            res.redirect('/connect/microauth')
+        } else {
+            res.sendStatus(401, 'You need to be authenticated to do this action.')
+        }
         return
     }
 	try {
@@ -190,14 +201,20 @@ app.get("/article_json/*", function (req, res) {
 app.delete("/article_json/*", function (req, res) {  
     if (REQUIRE_AUTH.DELETE && !req.session.oauth2) {
         req.session.next = req.url
-        res.sendStatus(401, 'You need to be authenticated to do this action.')
-        res.redirect('/connect/microauth')
+        if (REDIRECT_TO_AUTHORIZE) {
+            res.redirect('/connect/microauth')
+        } else {
+            res.sendStatus(401, 'You need to be authenticated to do this action.')
+        }
         return
     } else if (REQUIRE_AUTH.DELETE) {
         if (isCredentialExpired(req.session.oauth2)) {
             req.session.next = req.url
-            res.sendStatus(401, 'Signature has expired, please re-authenticate.')
-            res.redirect('/connect/microauth')
+            if (REDIRECT_TO_AUTHORIZE) {
+                res.redirect('/connect/microauth')
+            } else {
+                res.sendStatus(401, 'Signature has expired, please re-authenticate.')
+            }
             return
         }
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var express = require('express');
+var session = require('express-session')
 var bodyParser = require('body-parser')
 var jsonfile = require('jsonfile')
+var Grant = require('grant-express')
+var grant = new Grant(require('./config.json'))
 var morgan = require('morgan')
 var request = require('request');
 var MongoClient = require('mongodb').MongoClient;
@@ -11,9 +14,22 @@ var mdb_url = "mongodb://localhost:27017/IT2901";
 var indexer_url = "http://localhost:8001";
 
 var app = express();
+app.use(session({ secret: 'topkek' }))
+app.use(grant)
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use( bodyParser.json() );
 app.use(morgan('dev'));
+
+var REQUIRE_AUTH = {
+    LIST: false,
+    DETAIL: false,
+    SAVE: true,
+    DELETE: true
+}
+
+function isCredentialExpired(oauth2) {
+    return oauth2.issued_at + oauth2.expires_in < Date.now()
+}
 
 app.use(function(req, res, next) {
 	res.header("Access-Control-Allow-Origin", "*");
@@ -21,7 +37,20 @@ app.use(function(req, res, next) {
 	next();
 });
 
-app.post("/save_article", function (req, res) {	
+app.post("/save_article", function (req, res) {
+    if (REQUIRE_AUTH.SAVE && !req.session.oauth2) {
+        req.session.next = req.url
+        res.sendStatus(401, 'You need to be authenticated to do this action.')
+        // res.redirect('/connect/microauth')
+        return
+    } else if (REQUIRE_AUTH) {
+        if (isCredentialExpired(req.session.oauth2)) {
+            req.session.next = req.url
+            res.sendStatus(401, 'Signature has expired, please re-authenticate.')
+            // res.redirect('/connect/microauth')
+            return
+        }
+    }
 	try {
 		MongoClient.connect(mdb_url, function(err, db) {
 			assert.equal(null, err);
@@ -47,7 +76,40 @@ app.post("/save_article", function (req, res) {
 	}
 });
 
+app.get('/done', function (req, res) {
+
+    var err = req.query.error
+    if (err) {
+        res.send(JSON.stringify(err))
+        return
+    }
+
+    var oauth2 = {
+        access_token: req.query.raw.access_token,
+        refresh_token: req.query.raw.refresh_token,
+        scope: req.query.raw.scope,
+        expires_in: req.query.raw.expires_in,
+        token_type: req.query.raw.token_type,
+        issued_at: Date.now()
+    }
+
+    req.session.oauth2 = oauth2;
+
+    if (req.session.next) {
+        res.redirect(req.session.next)
+    } else {
+        res.send(JSON.stringify('You have authorized Content:Publishing to use your credentials on your behalf,' +
+        ' for posting content.'));
+    }
+})
+
 app.get("/list", function (req, res) {
+    if (REQUIRE_AUTH.LIST && (!req.session || !req.session.oauth2)) {
+        req.session.next = req.url
+        res.sendStatus(401, 'You need to be authenticated to do this action.')
+        // res.redirect('/connect/microauth')
+        return
+    }
 	try {
 		MongoClient.connect(mdb_url, function(err, db) {
 			assert.equal(null, err);
@@ -126,6 +188,19 @@ app.get("/article_json/*", function (req, res) {
 });
 
 app.delete("/article_json/*", function (req, res) {  
+    if (REQUIRE_AUTH.DELETE && !req.session.oauth2) {
+        req.session.next = req.url
+        res.sendStatus(401, 'You need to be authenticated to do this action.')
+        res.redirect('/connect/microauth')
+        return
+    } else if (REQUIRE_AUTH.DELETE) {
+        if (isCredentialExpired(req.session.oauth2)) {
+            req.session.next = req.url
+            res.sendStatus(401, 'Signature has expired, please re-authenticate.')
+            res.redirect('/connect/microauth')
+            return
+        }
+    }
 	try {
 		var article_name = req.url.substr(-24);
 		var new_id = new ObjectId(article_name);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
+    "express-session": "^1.13.0",
+    "grant": "^3.6.0",
+    "grant-express": "^3.6.0",
     "jsonfile": "^2.2.3",
     "mongodb": "^2.1.14",
     "morgan": "^1.7.0",


### PR DESCRIPTION
Use the dictionary in index.js to specify which views require access permissions. Run the OAuth2 provider at 127.0.0.1:8000 (or update config.json to where it actually runs).

Any attempt to access an access protected view (if access restriction is enabled) will be handled by OAuth2, either authenticating and authorizing the request, or redirecting to where you actually can authorize (feature toggled by setting `REDIRECT_TO_AUTHORIZE` to `true`).

Comments?
